### PR TITLE
Add .CBSDATA and .LOCAL_PROGRAM to sysntax highlighting and projectFo…

### DIFF
--- a/src/Modules/project.js
+++ b/src/Modules/project.js
@@ -49,6 +49,7 @@ class Project{
                     programName = this.document.lineAt(index).text.trim().split(' ')[0];
                     this.addInterfaceProgram(programName,index)
                     break;
+                case ".CBSDATA":
                 case ".END":
                     this.addProgramEnd(index)
                 default:

--- a/src/Modules/project.js
+++ b/src/Modules/project.js
@@ -40,6 +40,7 @@ class Project{
                 case ".CONDITION":
                 case ".AUXDATA":
                 case ".SIG_COMMENT":
+                case ".CBSDATA":
                     programName = this.document.lineAt(index).text.trim().split(' ')[0];
                     this.addSystemProgram(programName,index)
                     break;
@@ -49,7 +50,6 @@ class Project{
                     programName = this.document.lineAt(index).text.trim().split(' ')[0];
                     this.addInterfaceProgram(programName,index)
                     break;
-                case ".CBSDATA":
                 case ".END":
                     this.addProgramEnd(index)
                 default:

--- a/src/Modules/projectFormatter.js
+++ b/src/Modules/projectFormatter.js
@@ -49,6 +49,8 @@ function formatCode(code, languageId, lineCount) {
 		".INTER_PANEL_TITLE",
 		".INTER_PANEL_COLOR_D",
 		".SIG_COMMENT",
+		".CBSDATA",
+		".LOCAL_PROGRAM"
 	];
 	decreaseIndentPattern = [".END", "END", "ELSE", "UNTIL", "VALUE", "ANY", "SVALUE"];
 

--- a/syntaxes/as.tmLanguage.json
+++ b/syntaxes/as.tmLanguage.json
@@ -28,7 +28,7 @@
 		},
 		"program": {
 			"name": "as.keyword.control.program",
-			"match": "(\\.PROGRAM)|(\\.END)|(\\.TRANS)|(\\.JOINTS)|(\\.REALS)|(\\.STRINGS)|(\\.INTEGER)|(\\.ROBOTDATA1|(\\.OPE_INFO1))|(\\.SYSDATA)|(\\.CONDITION)|(\\.AUXDATA)|(\\.INTER_PANEL_D)|(\\.INTER_PANEL_TITLE)|(\\.INTER_PANEL_COLOR_D)|(\\.SIG_COMMENT)"
+			"match": "(\\.PROGRAM)|(\\.END)|(\\.TRANS)|(\\.JOINTS)|(\\.REALS)|(\\.STRINGS)|(\\.INTEGER)|(\\.ROBOTDATA1|(\\.OPE_INFO1))|(\\.SYSDATA)|(\\.CONDITION)|(\\.AUXDATA)|(\\.INTER_PANEL_D)|(\\.INTER_PANEL_TITLE)|(\\.INTER_PANEL_COLOR_D)|(\\.SIG_COMMENT)|(\\.CBSDATA)|(\\.LOCAL_PROGRAM)"
 		},
 		"flow": {
 			"name": "keyword.flow",

--- a/syntaxes/language-configuration.json
+++ b/syntaxes/language-configuration.json
@@ -26,7 +26,7 @@
 		["\"", "\""]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "\\.PROGRAM|\\.TRANS|\\.JOINTS|\\.REALS|\\.STRINGS|\\.INTEGER|\\.ROBOTDATA1|\\.OPE_INFO1|\\.SYSDATA|\\.CONDITION|\\.AUXDATA|\\.INTER_PANEL_D|\\.INTER_PANEL_TITLE|\\.INTER_PANEL_COLOR_D|\\.SIG_COMMENT|\\bTHEN|\\bELSE|\\bDO|\\bTO|\\bOF|\\bVALUE|\\bANY|\\bSVALUE",
+		"increaseIndentPattern": "\\.PROGRAM|\\.TRANS|\\.JOINTS|\\.REALS|\\.STRINGS|\\.INTEGER|\\.ROBOTDATA1|\\.OPE_INFO1|\\.SYSDATA|\\.CONDITION|\\.AUXDATA|\\.INTER_PANEL_D|\\.INTER_PANEL_TITLE|\\.INTER_PANEL_COLOR_D|\\.SIG_COMMENT|\\.CBSDATA|\\.LOCAL_PROGRAM|\\bTHEN|\\bELSE|\\bDO|\\bTO|\\bOF|\\bVALUE|\\bANY|\\bSVALUE",
 		"decreaseIndentPattern": "\\.END|\\bEND|\\bELSE|\\bUNTIL|\\bVALUE|\\bANY|\\bSVALUE"
 	},
 	"wordPattern": "[\\w.]+"


### PR DESCRIPTION
As described here: https://github.com/dRamosCode/kawasaki-as-vscode-extension/issues/7

Tested it locally and it did work with the changes in this fork.
Only thing I noticed is that the robot generates a `.End` instead of `.END`:

```
.LOCAL_PROGRAM.
...
.End
```
instead of
```
.LOCAL_PROGRAM.
...
.END
```

I could not get it to recognise `.End` in the fromatter. Don't know if it should