### PR TITLE
Project fromatter improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 *.vsix
 .vscode
+test.txt
+test.py

--- a/src/Modules/projectFormatter.js
+++ b/src/Modules/projectFormatter.js
@@ -27,11 +27,11 @@ function formatCode(code, languageId, lineCount) {
 	// Indentation Rules
 	increaseIndentPattern = [
 		".PROGRAM",
-		"THEN",
+		"\\bIF\\b.*?\\bTHEN\\b",
 		"ELSE",
 		"DO",
-		"TO",
-		"OF",
+		"\\bFOR\\b.*?\\bTO\\b",
+		"\\bCASE\\b.*?\\bOF\\b",
 		"VALUE",
 		"ANY",
 		"SVALUE",
@@ -52,7 +52,7 @@ function formatCode(code, languageId, lineCount) {
 		".CBSDATA",
 		".LOCAL_PROGRAM"
 	];
-	decreaseIndentPattern = [".END", "END", "ELSE", "UNTIL", "VALUE", "ANY", "SVALUE"];
+	decreaseIndentPattern = [".END", ".End", "END", "ELSE", "UNTIL", "VALUE", "ANY", "SVALUE"];
 
 	// Variables
 	let indentationLevel = 0;
@@ -89,7 +89,7 @@ function formatCode(code, languageId, lineCount) {
 
 		// Loop through decrease patterns and see if matches
 		decreaseIndentPattern.forEach((pattern, index) => {
-			const regExpPattern = new RegExp("\\b" + pattern + "\\b");
+			const regExpPattern = RegExp("(^|\\s)" + pattern + "(?=\\s|$)");
 			if (regExpPattern.test(testLine) == true && comment == false) {
 				indentationLevel--;
 				if (indentationLevel < 0) {
@@ -109,10 +109,9 @@ function formatCode(code, languageId, lineCount) {
 
 		// Loop through increase patterns and see if matches
 		increaseIndentPattern.forEach((pattern, index) => {
-			const regExpPattern = new RegExp("\\b" + pattern + "\\b");
+			const regExpPattern = RegExp("(^|\\s)" + pattern + "(?=\\s|$)");
 			if (
-				(regExpPattern.test(testLine) == true && comment == false && pattern.charAt(0) != ".") ||
-				(pattern.charAt(0) == "." && lines[i].charAt(0) == "." && lines[i].includes(pattern)) ||
+				(regExpPattern.test(testLine) == true && comment == false) ||
 				program == true
 			) {
 				indentationLevel++;

--- a/src/sidebarGenerator.js
+++ b/src/sidebarGenerator.js
@@ -82,13 +82,14 @@ function fillSidebar() {
     const activeFileName = activeEditor.document.fileName;
     const lastDotIndex = activeFileName.lastIndexOf(".");
     const extension = activeFileName.slice(lastDotIndex + 1);
-
-    // Non AS file
-    if (extension != "as") {
-      // Mark as non AS file in treeView
-      let userTreeProvider = new ProjectTreeProvider([{ label: "Not an AS file." }]);
-      let systemTreeProvider = new ProjectTreeProvider([{ label: "Not an AS file." }]);
-      let interfaceTreeProvider = new ProjectTreeProvider([{ label: "Not an AS file." }]);
+    const allowedExtensions = ["as", "pg"]
+    
+    // Non AS or PG file
+    if (!allowedExtensions.includes(extension)) {
+      // Mark as non AS or PG file in treeView
+      let userTreeProvider = new ProjectTreeProvider([{ label: "Not an AS or PG file." }]);
+      let systemTreeProvider = new ProjectTreeProvider([{ label: "Not an AS or PG file." }]);
+      let interfaceTreeProvider = new ProjectTreeProvider([{ label: "Not an AS or PG file." }]);
       const userPrograms = vscode.window.createTreeView("user", { treeDataProvider: userTreeProvider });
       const systemPrograms = vscode.window.createTreeView("system", { treeDataProvider: systemTreeProvider });
       const interfacePrograms = vscode.window.createTreeView("interface", { treeDataProvider: interfaceTreeProvider });

--- a/syntaxes/as.tmLanguage.json
+++ b/syntaxes/as.tmLanguage.json
@@ -28,7 +28,7 @@
 		},
 		"program": {
 			"name": "as.keyword.control.program",
-			"match": "(\\.PROGRAM)|(\\.END)|(\\.TRANS)|(\\.JOINTS)|(\\.REALS)|(\\.STRINGS)|(\\.INTEGER)|(\\.ROBOTDATA1|(\\.OPE_INFO1))|(\\.SYSDATA)|(\\.CONDITION)|(\\.AUXDATA)|(\\.INTER_PANEL_D)|(\\.INTER_PANEL_TITLE)|(\\.INTER_PANEL_COLOR_D)|(\\.SIG_COMMENT)|(\\.CBSDATA)|(\\.LOCAL_PROGRAM)"
+			"match": "(\\.PROGRAM)|(\\.END)|(\\.TRANS)|(\\.JOINTS)|(\\.REALS)|(\\.STRINGS)|(\\.INTEGER)|(\\.ROBOTDATA1|(\\.OPE_INFO1))|(\\.SYSDATA)|(\\.CONDITION)|(\\.AUXDATA)|(\\.INTER_PANEL_D)|(\\.INTER_PANEL_TITLE)|(\\.INTER_PANEL_COLOR_D)|(\\.SIG_COMMENT)|(\\.CBSDATA)|(\\.LOCAL_PROGRAM)|(\\.End)"
 		},
 		"flow": {
 			"name": "keyword.flow",

--- a/syntaxes/language-configuration.json
+++ b/syntaxes/language-configuration.json
@@ -26,7 +26,7 @@
 		["\"", "\""]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "\\.PROGRAM|\\.TRANS|\\.JOINTS|\\.REALS|\\.STRINGS|\\.INTEGER|\\.ROBOTDATA1|\\.OPE_INFO1|\\.SYSDATA|\\.CONDITION|\\.AUXDATA|\\.INTER_PANEL_D|\\.INTER_PANEL_TITLE|\\.INTER_PANEL_COLOR_D|\\.SIG_COMMENT|\\.CBSDATA|\\.LOCAL_PROGRAM|\\bTHEN|\\bELSE|\\bDO|\\bTO|\\bOF|\\bVALUE|\\bANY|\\bSVALUE",
+		"increaseIndentPattern": "\\.PROGRAM|\\.TRANS|\\.JOINTS|\\.REALS|\\.STRINGS|\\.INTEGER|\\.ROBOTDATA1|\\.OPE_INFO1|\\.SYSDATA|\\.CONDITION|\\.AUXDATA|\\.INTER_PANEL_D|\\.INTER_PANEL_TITLE|\\.INTER_PANEL_COLOR_D|\\.SIG_COMMENT|\\.CBSDATA|\\.LOCAL_PROGRAM|\\bIF\\b.*?\\bTHEN\\b|\\bELSE|\\bDO|\\bFOR\\b.*?\\bTO\\b|\\bCASE\\b.*?\\bOF\\b|\\bVALUE|\\bANY|\\bSVALUE",
 		"decreaseIndentPattern": "\\.END|\\bEND|\\bELSE|\\bUNTIL|\\bVALUE|\\bANY|\\bSVALUE"
 	},
 	"wordPattern": "[\\w.]+"


### PR DESCRIPTION
Changed the REGEX filter in projectFormatter.js

> The original REGEX could never match the patterns with a `.` in front. \b expects a word boundry, which a `.` is not.
> Instead of just looking for the word THEN, TO and OF, match `IF ... THEN`,` FOR ... TO` and `CASE ... OF` patterns
>>When these words where mentiond in a line, lines would be indented incorrectly.
```
    IF TRUE THEN
        $text = "THIS IS SAMPLE TEXT TO SHOW INDENT"
            PRINT $text
    END
```
>>This still happens with the other words that not match a structure, but this limits the possible cases where this happens.

Added .End to syntax and formatter.

>I'm not sure how .LOCAL_PROGRAM is generated, I cant recrate it in K-ROSET. But this is my experience:
>Our robot generates `.LOCAL_PROGRAM test ... .End`. This was not recognised as syntax and not formatted.

Added PG files to the allowd extensions for the project sidebar.

> Now you can also see all the programs in a .PG file

